### PR TITLE
docs: fix path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ List of all options can be found in [container's documentation](./docs/container
 ### From releases
 
 - `Download the zip of the latest version for your architecture`
-- `unzip waypoint-plugin-scaleway-container_*.zip -d ${HOME}/.config/waypoint/plugins/`
+- `unzip waypoint-plugin-scaleway-container_*.zip -d ${HOME}/.config/.waypoint/plugins/`
 
 ### From sources
 


### PR DESCRIPTION
```
2023-03-13T16:33:04.959+0100 [DEBUG] waypoint.runner: plugin search path: job_id=01GVDSN3QEQA7S0W9V1Q3DY3XV job_op="*gen.Job_Up" path=["/Users/sieben/workspace/waypoint-demo", "/Users/sieben/workspace/waypoint-demo/.waypoint/plugins", "/Users/sieben/Library/Preferences/waypoint/plugins", "/Users/sieben/.config/.waypoint/plugins"]
```